### PR TITLE
fix build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.15)
-set(CMAKE_OSX_ARCHITECTURES x86_64 arm64)
 project(ECMAPPER)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -8,7 +7,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     message("apple config")
 
     if(NOT CMAKE_OSX_ARCHITECTURES)
-        set(CMAKE_OSX_ARCHITECTURES "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+        set(CMAKE_OSX_ARCHITECTURES x86_64 arm64)
     endif()
     message(STATUS "CMAKE_OSX_ARCHITECTURES ${CMAKE_OSX_ARCHITECTURES}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,6 @@ endif()
 add_subdirectory(JUCE)
 
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-	juce_set_vst2_sdk_path("${CMAKE_CURRENT_LIST_DIR}/JUCE/modules/juce_audio_processors/format_types/VST3_SDK")
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    juce_set_vst2_sdk_path("$ENV{HOME}/SDKs/vst3-sdk")
-endif ()
-
-
-
 add_subdirectory(EigenLite/eigenapi)
 add_subdirectory(ECMapper)
 add_subdirectory(EigenCore)

--- a/ECMapper/CMakeLists.txt
+++ b/ECMapper/CMakeLists.txt
@@ -55,7 +55,7 @@ juce_add_plugin(ECMAP
         COPY_PLUGIN_AFTER_BUILD TRUE                # Should the plugin be installed to a default location after building?
         PLUGIN_MANUFACTURER_CODE TITO                 # A four-character manufacturer id with at least one upper-case character
         PLUGIN_CODE ECMA                            # A unique four-character plugin id with at least one upper-case character
-        FORMATS VST VST3                            # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
+        FORMATS VST3                            # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
         PRODUCT_NAME "ECMA")                        # The name of the final executable, which can differ from the target name
 
 # `juce_generate_juce_header` will create a JuceHeader.h for a given target, which will be generated
@@ -141,6 +141,5 @@ target_link_libraries(ECMAP PRIVATE
         )
 
 
-set_target_properties(${PROJECT_NAME}_VST PROPERTIES PREFIX "")
 set_target_properties(${PROJECT_NAME}_VST3 PROPERTIES PREFIX "")
 

--- a/EigenCore/CMakeLists.txt
+++ b/EigenCore/CMakeLists.txt
@@ -71,7 +71,7 @@ juce_add_plugin(EigenCore
         # IS_MIDI_EFFECT TRUE/FALSE                 # Is this plugin a MIDI effect?
         # EDITOR_WANTS_KEYBOARD_FOCUS TRUE/FALSE    # Does the editor need keyboard focus?
         VST3_CATEGORIES "Tools"
-        COPY_PLUGIN_AFTER_BUILD FALSE               # Should the plugin be installed to a default location after building?
+        COPY_PLUGIN_AFTER_BUILD TRUE                # Should the plugin be installed to a default location after building?
         PLUGIN_MANUFACTURER_CODE Manu                 # A four-character manufacturer id with at least one upper-case character
         PLUGIN_CODE Eyb4                            # A unique four-character plugin id with at least one upper-case character
         FORMATS  VST3  Standalone                   # The formats to build. Other valid formats are: AAX Unity VST AU AUv3

--- a/EigenCore/CMakeLists.txt
+++ b/EigenCore/CMakeLists.txt
@@ -74,7 +74,7 @@ juce_add_plugin(EigenCore
         COPY_PLUGIN_AFTER_BUILD FALSE               # Should the plugin be installed to a default location after building?
         PLUGIN_MANUFACTURER_CODE Manu                 # A four-character manufacturer id with at least one upper-case character
         PLUGIN_CODE Eyb4                            # A unique four-character plugin id with at least one upper-case character
-        FORMATS Standalone VST3                     # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
+        FORMATS  VST3  Standalone                   # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
         PRODUCT_NAME ${BINARY_NAME})                # The name of the final executable, which can differ from the target name
 
 # `juce_generate_juce_header` will create a JuceHeader.h for a given target, which will be generated
@@ -158,7 +158,13 @@ set_target_properties(${PROJECT_NAME}_VST3 PROPERTIES PREFIX "")
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   message("Creating universal picodecoder and copying it to bundle")
-  add_custom_command(TARGET EigenCore_Standalone EigenCore_VST3
+  add_custom_command(TARGET EigenCore_Standalone 
+          PRE_BUILD COMMAND lipo -create
+                "../../EigenLite/resources/libpico_decoder_x86_64_1_0_0.dylib"
+                "../../EigenLite/resources/libpico_decoder_arm64_1_0_0.dylib"
+                -output "EigenCore_artefacts/libpicodecoder.dylib"
+  )
+  add_custom_command(TARGET EigenCore_VST3
           PRE_BUILD COMMAND lipo -create
                 "../../EigenLite/resources/libpico_decoder_x86_64_1_0_0.dylib"
                 "../../EigenLite/resources/libpico_decoder_arm64_1_0_0.dylib"


### PR DESCRIPTION
VST2 cannot be built with embedded juce vst3_sdk  (does not contain vst2 interfaces) - remove vst2 target
also, remove vst2 path as unnecessary


built targets wrong on libo create step 

